### PR TITLE
fix: datatype check on "val"

### DIFF
--- a/cloudlink/supporter.py
+++ b/cloudlink/supporter.py
@@ -64,7 +64,7 @@ class supporter:
 
         # Method default keys and permitted datatypes
         self.keydefaults = {
-            "val": [str, int, float, dict],
+            "val": [str, int, float, list, dict],
             "id": [str, int, dict, set, list],
             "listener": [str, dict, float, int],
             "rooms": [str, list],


### PR DESCRIPTION
Allow for lists within the "val" key of a command.